### PR TITLE
fix(english-conversation): run TTS in foreground to prevent audio loss

### DIFF
--- a/skills/english-conversation/SKILL.md
+++ b/skills/english-conversation/SKILL.md
@@ -63,12 +63,13 @@ Silently track every recast you perform. Maintain an internal list:
 This list is ONLY revealed at session end when the user requests a summary.
 Do NOT mention tracking during conversation.
 
-## TTS: Speak Every Response
+## TTS: Speak Every Response (MANDATORY)
 
-After composing your text response, ALWAYS speak it aloud via Bash:
+After composing your text response, you MUST run this Bash command to speak it aloud.
+Do NOT skip this step. Do NOT use background execution (`&`).
 
 ```bash
-say -v Samantha -r 170 '{plain_text_response}' &
+say -v Samantha -r 170 '{plain_text_response}'
 ```
 
 ### TTS Text Preparation
@@ -147,7 +148,7 @@ When the session ends, generate:
 
 After the summary, speak a brief closing:
 ```bash
-say -v Samantha -r 170 'Great session! You did really well today. See you next time!' &
+say -v Samantha -r 170 'Great session! You did really well today. See you next time!'
 ```
 
 If no corrections were needed, celebrate that in the summary.


### PR DESCRIPTION
## Summary
- Remove background execution (`&`) from `say` TTS commands
- Strengthen instruction wording to MANDATORY with explicit "Do NOT skip" / "Do NOT use `&`"

## Root Cause
Claude Code's Bash tool runs commands in an eval-based temporary shell. Background processes (`&`) get orphaned/killed when the shell exits, causing `say` audio to silently fail.

## Test plan
- [x] `say -v Samantha -r 170 'test'` produces audible output (foreground)
- [x] Verified on macOS with Samantha voice installed
- [ ] Invoke `/english-conversation` skill and confirm voice plays on each response

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * TTS requirements are now mandatory for all responses in the English conversation skill
  * Voice command execution changed to run synchronously instead of in background
  * Clarified explicit requirements for spoken responses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->